### PR TITLE
API 실패 시 사용자 안내 추가 (전면 표준화 Phase 3-1)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,7 +6,11 @@ package-lock.json
 # 자동 생성 파일 (scripts/sync-version.js)
 src/constants/version.js
 
-# GitHub Actions가 통째로 재생성한다 (.github/scripts/changelog_manager.py)
-# 포맷을 적용하면 워크플로우가 다시 쓸 때마다 불필요한 diff가 발생한다
+# GitHub Actions가 자동으로 수정한다.
+# 포맷을 적용하면 워크플로우가 다시 쓸 때마다 어긋나 CI 포맷 체크가 실패한다.
+#
+# CHANGELOG: .github/scripts/changelog_manager.py가 통째로 재생성
+# README: PROJECT-README-VERSION-UPDATE 워크플로우가 배포마다 버전 라인 갱신
 CHANGELOG.json
 CHANGELOG.md
+README.md

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -64,6 +64,15 @@
 
 ## 개발 환경 주의사항
 
+### 자동 생성 파일은 포맷 대상이 아니다
+
+`CHANGELOG.json`, `CHANGELOG.md`, `README.md`는 GitHub Actions가 자동으로 수정한다.
+Prettier를 적용하면 워크플로우가 다시 쓸 때 포맷이 어긋나 **CI 포맷 체크가 실패**한다.
+`.prettierignore`에 등록되어 있으니 빼지 않는다.
+
+(Phase 0에서 README를 "라인 단위 치환이라 안전하다"고 판단해 포함했다가, 실제로
+배포 후 CI가 깨지는 것을 확인하고 제외했다.)
+
 ### 린트와 빌드는 분리되어 있다
 
 `npm run build`와 `npm start`는 `DISABLE_ESLINT_PLUGIN=true`로 실행된다. CRA가 webpack

--- a/src/hooks/useRankingData.js
+++ b/src/hooks/useRankingData.js
@@ -96,7 +96,9 @@ export const useRankingData = (pageSize = 20) => {
           ...prev,
           isLoading: false,
           isInitialLoading: false,
-          error: error.message || "데이터를 불러오는 중 오류가 발생했습니다.",
+          // 원본 메시지(axios의 영문 문구)를 그대로 보여주면 사용자가 이해할 수 없다.
+          // 상세 내용은 위 logger.error로만 남긴다.
+          error: "랭킹을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.",
         }));
       }
     }

--- a/src/hooks/useRankingData.test.js
+++ b/src/hooks/useRankingData.test.js
@@ -100,14 +100,19 @@ describe("useRankingData 에러 처리", () => {
     jest.clearAllMocks();
   });
 
-  it("요청이 실패하면 에러 메시지를 상태에 담는다", async () => {
-    axios.get.mockRejectedValue(new Error("서버 오류"));
+  // axios의 영문 원본 메시지를 사용자에게 그대로 보여주면 안 된다.
+  // 상세 내용은 로거로만 남기고 화면에는 한국어 안내를 띄운다.
+  it("요청이 실패하면 사용자용 한국어 안내를 상태에 담는다", async () => {
+    axios.get.mockRejectedValue(new Error("Request failed with status code 403"));
 
     const { result } = renderHook(() => useRankingData());
 
     await waitFor(() => expect(result.current.data.error).toBeTruthy());
 
-    expect(result.current.data.error).toBe("서버 오류");
+    expect(result.current.data.error).toBe(
+      "랭킹을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+    );
+    expect(result.current.data.error).not.toContain("status code");
     expect(result.current.data.isLoading).toBe(false);
     expect(result.current.data.isInitialLoading).toBe(false);
   });

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { House, Trophy, Controller } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
@@ -7,8 +7,56 @@ import styled from "styled-components";
 import GlassCard from "../components/GlassCard";
 import ProfileContent from "../components/ProfileContent";
 import StatsContent from "../components/StatsContent";
-import { getAuthToken } from "../utils/auth";
 import axios from "../utils/axios";
+import { logger } from "../utils/logger";
+
+const ErrorPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 2.5rem 2rem;
+  max-width: 26rem;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(15px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+`;
+
+const ErrorMessage = styled.p`
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
+`;
+
+const RetryButton = styled.button`
+  padding: 0.7rem 1.8rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(200, 182, 226, 0.9);
+  color: white;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background: rgba(200, 182, 226, 1);
+    transform: translateY(-2px);
+  }
+`;
+
+/** 조회 실패 시 상황을 알리고 재시도 동선을 제공한다 */
+const ErrorContent = ({ message, onRetry }) => (
+  <ErrorPanel>
+    <ErrorMessage>{message}</ErrorMessage>
+    <RetryButton type="button" onClick={onRetry}>
+      다시 시도
+    </RetryButton>
+  </ErrorPanel>
+);
 
 const ProfileWrapper = styled(motion.div)`
   position: fixed;
@@ -199,23 +247,25 @@ const ButtonSpan = styled.span`
 
 function Profile() {
   const [profile, setProfile] = useState(null);
+  const [loadError, setLoadError] = useState(null);
+
+  // 조회에 실패해도 에러 상태가 없으면 스켈레톤이 영원히 표시된다.
+  // 사용자는 계속 로딩 중이라고 여기고 기다리게 된다.
+  const fetchProfile = useCallback(async () => {
+    setLoadError(null);
+    try {
+      // 토큰은 axios 인터셉터가 주입한다
+      const response = await axios.get("/api/my-page");
+      setProfile(response?.data);
+    } catch (error) {
+      logger.error("프로필 조회 실패:", error);
+      setLoadError("내 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+    }
+  }, []);
 
   useEffect(() => {
-    const fetchProfile = async () => {
-      try {
-        const response = await axios.get("/api/my-page", {
-          headers: {
-            Authorization: `Bearer ${getAuthToken()}`,
-          },
-        });
-        setProfile(response?.data);
-      } catch (error) {
-        // 프로필 로딩 실패 시 처리 (로그는 제거)
-      }
-    };
-
     fetchProfile();
-  }, []);
+  }, [fetchProfile]);
 
   // 스태거 애니메이션을 위한 variants
   const containerVariants = {
@@ -379,7 +429,11 @@ function Profile() {
   return (
     <ProfileWrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 1 }}>
       <AnimatePresence mode="wait">
-        {!profile ? (
+        {loadError ? (
+          <motion.div key="error" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+            <ErrorContent message={loadError} onRetry={fetchProfile} />
+          </motion.div>
+        ) : !profile ? (
           <motion.div key="loading" exit={{ opacity: 0, scale: 0.95 }}>
             <LoadingContent />
           </motion.div>


### PR DESCRIPTION
## 관련 이슈

- https://github.com/bagle-ggul/Bagel-Frontend/issues/100

## 개요

Phase 3의 **첫 항목인 "실패 화면 처리"** 입니다. 이슈 #100의 나머지(디자인 토큰 재설계, 대형 화면 분해)는 별도 PR로 이어집니다.

착수 전 3해상도 점검 중 발견한 문제입니다. **API 호출이 실패했을 때 사용자가 상황을 알 수 없는** 두 화면을 고쳤습니다.

## 고친 것

### 1. 프로필 — 실패해도 로딩이 끝나지 않았습니다

`catch` 블록이 비어 있었습니다.

```js
} catch (error) {
  // 프로필 로딩 실패 시 처리 (로그는 제거)
}
```

에러 상태가 없으니 `!profile` 조건이 계속 참이고, **스켈레톤 로딩 UI가 영원히 표시**됐습니다. 사용자는 계속 로딩 중이라 여기고 기다리게 됩니다.

에러 상태와 안내 화면, 재시도 버튼을 추가했습니다.

> **정정**: 최초 점검에서 "검은 화면만 표시된다"고 기록했으나 **오판이었습니다.** 1초 페이드인 애니메이션 도중에 캡처된 것이었고, 실제로는 스켈레톤이 정상 표시됩니다. 다만 **"실패해도 영원히 로딩"** 문제는 실재했습니다.

### 2. 랭킹 — 영문 원본 에러가 그대로 노출됐습니다

```
Request failed with status code 403
```

`error.message`를 그대로 화면에 담고 있었습니다. 준비된 한국어 폴백은 `message`가 비어 있을 때만 쓰이므로 사실상 동작하지 않았습니다.

사용자에게는 한국어 안내를, 원본은 로거로만 남기도록 바꿨습니다.

### 3. Phase 1에서 놓친 중복 헤더

`Profile.jsx`에 `Authorization: Bearer ${getAuthToken()}` 수동 헤더가 남아 있었습니다. `auth.js`를 경유했기 때문에 `localStorage` 룰에 걸리지 않아 살아남은 것입니다. 인터셉터가 처리하므로 제거했습니다.

## 검증

### 자동

| 명령 | 결과 |
|---|---|
| `format:check` | ✅ exit 0 |
| `lint` | ✅ exit 0 |
| `test:ci` | ✅ 103 tests |
| `build` | ✅ Compiled successfully |

### 브라우저 실동작

403 상황을 재현해 확인했습니다.

| 화면 | 수정 전 | 수정 후 |
|---|---|---|
| 프로필 | 스켈레톤이 영원히 표시 | `내 정보를 불러오지 못했습니다...` + 다시 시도 |
| 랭킹 | `Request failed with status code 403` | `랭킹을 불러오지 못했습니다...` + 다시 시도 |

## 이슈 #100의 남은 작업

- 3해상도 전 화면 캡처 및 문제 목록 작성
- 디자인 토큰 2계층 재설계
- `Home.jsx`(2193줄) · `Board.jsx`(1043줄) 분해
- 인라인 스타일 36곳 흡수
- `unknown prop "progress"` 경고 해소

대형 파일 분해는 `Home.jsx`에 로그인·회원가입 폼이 들어 있어 회귀 위험이 큽니다. 분해 전후 캡처 비교와 실제 로그인 동선 확인을 포함해 별도로 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로필을 불러오지 못할 때 오류 안내 화면과 “다시 시도” 버튼을 제공합니다.
  * 재시도하여 프로필 정보를 다시 불러올 수 있습니다.

* **버그 수정**
  * 랭킹 및 프로필 조회 실패 시 기술적인 원문 오류 대신 이해하기 쉬운 안내 문구를 표시합니다.
  * 오류 세부 정보가 사용자 화면에 노출되지 않도록 개선했습니다.

* **문서**
  * 자동 생성 파일의 서식 검사 제외 기준과 관련 CI 동작을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->