### PR TITLE
Home 화면의 모달 컴포넌트 분리 (전면 표준화 Phase 3-3)

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,6 +10,7 @@ import { logger } from "../utils/logger";
 import { isMusicMuted, setMusicMuted } from "../utils/storage";
 
 import CreditsModal from "./Home/CreditsModal";
+import LoginModal from "./Home/LoginModal";
 import LoginRequiredModal from "./Home/LoginRequiredModal";
 import {
   BirthDateContainer,
@@ -73,7 +74,6 @@ function Home() {
   // 로그인 폼 상태
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [error, setError] = useState("");
 
   // 회원가입 폼 상태
@@ -196,7 +196,6 @@ function Home() {
     setError("");
     setEmail("");
     setPassword("");
-    setIsPasswordVisible(false);
   };
 
   const closeLoginModal = () => {
@@ -204,7 +203,6 @@ function Home() {
     setError("");
     setEmail("");
     setPassword("");
-    setIsPasswordVisible(false);
   };
 
   const handleSignup = async (event) => {
@@ -870,107 +868,15 @@ function Home() {
           </ModalOverlay>
         )}
         {showLogin && (
-          <ModalOverlay
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={closeLoginModal}
-          >
-            <ModalContent
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.8, opacity: 0 }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <ModalTitle>로그인</ModalTitle>
-              <LoginForm onSubmit={handleLogin}>
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <GlassInput
-                    type="email"
-                    placeholder="이메일을 입력해주세요"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                  />
-                </InputWrapper>
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <PasswordInputWrapper>
-                    <GlassInput
-                      type={isPasswordVisible ? "text" : "password"}
-                      placeholder="비밀번호를 입력해주세요"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
-                    <PasswordToggleButton
-                      type="button"
-                      onClick={() => setIsPasswordVisible(!isPasswordVisible)}
-                    >
-                      {isPasswordVisible ? (
-                        // Eye Open (보기)
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                          <circle cx="12" cy="12" r="3" />
-                        </svg>
-                      ) : (
-                        // Eye Closed (숨기기)
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-                          <line x1="1" y1="1" x2="23" y2="23" />
-                        </svg>
-                      )}
-                    </PasswordToggleButton>
-                  </PasswordInputWrapper>
-                </InputWrapper>
-                <SubmitButton type="submit" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  로그인
-                </SubmitButton>
-                {error && (
-                  <ErrorMessage
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.3 }}
-                  >
-                    {error}
-                  </ErrorMessage>
-                )}
-              </LoginForm>
-              <IconCloseButton
-                onClick={closeLoginModal}
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.95 }}
-                aria-label="로그인 모달 닫기"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </IconCloseButton>
-            </ModalContent>
-          </ModalOverlay>
+          <LoginModal
+            email={email}
+            password={password}
+            error={error}
+            onEmailChange={(e) => setEmail(e.target.value)}
+            onPasswordChange={(e) => setPassword(e.target.value)}
+            onSubmit={handleLogin}
+            onClose={closeLoginModal}
+          />
         )}
         {showLoginRequired && (
           <LoginRequiredModal

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,6 +9,8 @@ import axios from "../utils/axios";
 import { logger } from "../utils/logger";
 import { isMusicMuted, setMusicMuted } from "../utils/storage";
 
+import CreditsModal from "./Home/CreditsModal";
+import LoginRequiredModal from "./Home/LoginRequiredModal";
 import {
   BirthDateContainer,
   BirthDateRow,
@@ -21,7 +23,6 @@ import {
   ButtonWrapper,
   ChangelogLink,
   CharacterWrapper,
-  DetailRow,
   ErrorMessage,
   GenderButton,
   GenderButtonGroup,
@@ -42,8 +43,6 @@ import {
   MbtiResult,
   MbtiRow,
   MbtiTitle,
-  MemberName,
-  MemberRole,
   MobileCharacterWrapper,
   MobileContainer,
   MobileMainWrapper,
@@ -58,11 +57,6 @@ import {
   SecondaryButtonModal,
   SubmitButton,
   Subtitle,
-  TeamDetails,
-  TeamInfo,
-  TeamList,
-  TeamMember,
-  TeamName,
   Title,
   Wrapper,
 } from "./Home.styled";
@@ -341,15 +335,6 @@ function Home() {
     }
   };
 
-  const teamMembers = [
-    { name: "서새찬", role: "Backend, Frontend, 발표 및 Document 문서화" },
-    { name: "이창규", role: "Frontend, 이미지 생성" },
-    { name: "강인권", role: "Frontend" },
-    { name: "신혁수", role: "Frontend" },
-    { name: "김현서", role: "스토리 제작 및 전체 통괄, 이미지 생성" },
-    { name: "김도현", role: "스토리 제작 및 전체 통괄, 이미지 생성" },
-  ];
-
   return (
     <div>
       <Wrapper />
@@ -549,70 +534,7 @@ function Home() {
       )}
 
       <AnimatePresence>
-        {showCredits && (
-          <ModalOverlay
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={() => setShowCredits(false)}
-          >
-            <ModalContent
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.8, opacity: 0 }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <ModalTitle>크레딧</ModalTitle>
-              <TeamInfo>
-                <TeamName>그녀가사다준 뉴욕 베이글 (그뉴베)</TeamName>
-                <TeamDetails>
-                  <DetailRow>
-                    <span>날짜: 2024.05.17 | 주제: 파도, 시간, 미로</span>
-                  </DetailRow>
-                  <DetailRow>
-                    <span>세종대학교 소프트웨어융합대학 해커톤</span>
-                  </DetailRow>
-                </TeamDetails>
-              </TeamInfo>
-              <TeamList>
-                {teamMembers.map((member, index) => (
-                  <motion.div
-                    key={index}
-                    initial={{ opacity: 0, x: -20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: index * 0.1 }}
-                  >
-                    <TeamMember>
-                      <MemberName>{member.name}</MemberName>
-                      <MemberRole>{member.role}</MemberRole>
-                    </TeamMember>
-                  </motion.div>
-                ))}
-              </TeamList>
-              <IconCloseButton
-                onClick={() => setShowCredits(false)}
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.95 }}
-                aria-label="크레딧 모달 닫기"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </IconCloseButton>
-            </ModalContent>
-          </ModalOverlay>
-        )}
-
+        {showCredits && <CreditsModal onClose={() => setShowCredits(false)} />}
         {showSignup && (
           <ModalOverlay
             initial={{ opacity: 0 }}
@@ -947,7 +869,6 @@ function Home() {
             </ModalContent>
           </ModalOverlay>
         )}
-
         {showLogin && (
           <ModalOverlay
             initial={{ opacity: 0 }}
@@ -1051,88 +972,19 @@ function Home() {
             </ModalContent>
           </ModalOverlay>
         )}
-
         {showLoginRequired && (
-          <ModalOverlay
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={closeLoginRequiredModal}
-          >
-            <ModalContent
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.8, opacity: 0 }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <ModalTitle>로그인 필요</ModalTitle>
-              <TeamInfo>
-                <TeamDetails>
-                  <DetailRow>
-                    <span>랭킹 보기는 로그인 후 이용할 수 있습니다.</span>
-                  </DetailRow>
-                  <DetailRow>
-                    <span>로그인하여 다른 플레이어들과 점수를 비교해보세요!</span>
-                  </DetailRow>
-                </TeamDetails>
-              </TeamInfo>
-              <div
-                style={{
-                  display: "flex",
-                  gap: "1rem",
-                  justifyContent: "center",
-                  marginTop: "1.5rem",
-                }}
-              >
-                <SubmitButton
-                  type="button"
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  onClick={() => {
-                    setShowLoginRequired(false);
-                    setShowLogin(true);
-                  }}
-                >
-                  로그인하기
-                </SubmitButton>
-                <SubmitButton
-                  type="button"
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  onClick={() => {
-                    setShowLoginRequired(false);
-                    setShowSignup(true);
-                  }}
-                  style={{
-                    background: "rgba(255, 255, 255, 0.15)",
-                    border: "1px solid rgba(255, 255, 255, 0.3)",
-                  }}
-                >
-                  회원가입하기
-                </SubmitButton>
-              </div>
-              <IconCloseButton
-                onClick={closeLoginRequiredModal}
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.95 }}
-                aria-label="모달 닫기"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </IconCloseButton>
-            </ModalContent>
-          </ModalOverlay>
+          <LoginRequiredModal
+            onClose={closeLoginRequiredModal}
+            onGoLogin={() => {
+              setShowLoginRequired(false);
+              setShowLogin(true);
+            }}
+            onGoSignup={() => {
+              setShowLoginRequired(false);
+              setShowSignup(true);
+            }}
+          />
+        )}
         )}
       </AnimatePresence>
 

--- a/src/pages/Home/CreditsModal.jsx
+++ b/src/pages/Home/CreditsModal.jsx
@@ -1,0 +1,90 @@
+import { motion } from "framer-motion";
+import React from "react";
+
+import {
+  DetailRow,
+  IconCloseButton,
+  MemberName,
+  MemberRole,
+  ModalContent,
+  ModalOverlay,
+  ModalTitle,
+  TeamDetails,
+  TeamInfo,
+  TeamList,
+  TeamMember,
+  TeamName,
+} from "../Home.styled";
+
+/** 팀 정보는 화면에만 쓰이는 고정 데이터라 컴포넌트 옆에 둔다 */
+const TEAM_MEMBERS = [
+  { name: "서새찬", role: "Backend, Frontend, 발표 및 Document 문서화" },
+  { name: "이창규", role: "Frontend, 이미지 생성" },
+  { name: "강인권", role: "Frontend" },
+  { name: "신혁수", role: "Frontend" },
+  { name: "김현서", role: "스토리 제작 및 전체 통괄, 이미지 생성" },
+  { name: "김도현", role: "스토리 제작 및 전체 통괄, 이미지 생성" },
+];
+
+const CloseIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+/** 팀·해커톤 정보를 보여주는 크레딧 모달 */
+function CreditsModal({ onClose }) {
+  return (
+    <ModalOverlay
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      onClick={onClose}
+    >
+      <ModalContent
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.8, opacity: 0 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ModalTitle>크레딧</ModalTitle>
+        <TeamInfo>
+          <TeamName>그녀가사다준 뉴욕 베이글 (그뉴베)</TeamName>
+          <TeamDetails>
+            <DetailRow>
+              <span>날짜: 2024.05.17 | 주제: 파도, 시간, 미로</span>
+            </DetailRow>
+            <DetailRow>
+              <span>세종대학교 소프트웨어융합대학 해커톤</span>
+            </DetailRow>
+          </TeamDetails>
+        </TeamInfo>
+        <TeamList>
+          {TEAM_MEMBERS.map((member, index) => (
+            <motion.div
+              key={member.name}
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <TeamMember>
+                <MemberName>{member.name}</MemberName>
+                <MemberRole>{member.role}</MemberRole>
+              </TeamMember>
+            </motion.div>
+          ))}
+        </TeamList>
+        <IconCloseButton
+          onClick={onClose}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          aria-label="크레딧 모달 닫기"
+        >
+          <CloseIcon />
+        </IconCloseButton>
+      </ModalContent>
+    </ModalOverlay>
+  );
+}
+
+export default CreditsModal;

--- a/src/pages/Home/LoginModal.jsx
+++ b/src/pages/Home/LoginModal.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+
+import {
+  ErrorMessage,
+  GlassInput,
+  IconCloseButton,
+  InputWrapper,
+  LoginForm,
+  ModalContent,
+  ModalOverlay,
+  ModalTitle,
+  SubmitButton,
+} from "../Home.styled";
+
+import PasswordField from "./PasswordField";
+
+const CloseIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+/** 로그인 모달. 폼 상태는 화면(Home)이 소유하고 이 컴포넌트는 표현만 담당한다. */
+function LoginModal({
+  email,
+  password,
+  error,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+  onClose,
+}) {
+  return (
+    <ModalOverlay
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      onClick={onClose}
+    >
+      <ModalContent
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.8, opacity: 0 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ModalTitle>로그인</ModalTitle>
+        <LoginForm onSubmit={onSubmit}>
+          <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <GlassInput
+              type="email"
+              placeholder="이메일을 입력해주세요"
+              value={email}
+              onChange={onEmailChange}
+              required
+            />
+          </InputWrapper>
+          <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <PasswordField value={password} onChange={onPasswordChange} />
+          </InputWrapper>
+
+          <SubmitButton type="submit" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            로그인
+          </SubmitButton>
+          {error && (
+            <ErrorMessage
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              {error}
+            </ErrorMessage>
+          )}
+        </LoginForm>
+        <IconCloseButton
+          onClick={onClose}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          aria-label="로그인 모달 닫기"
+        >
+          <CloseIcon />
+        </IconCloseButton>
+      </ModalContent>
+    </ModalOverlay>
+  );
+}
+
+export default LoginModal;

--- a/src/pages/Home/LoginRequiredModal.jsx
+++ b/src/pages/Home/LoginRequiredModal.jsx
@@ -1,0 +1,94 @@
+import React from "react";
+import styled from "styled-components";
+
+import {
+  DetailRow,
+  IconCloseButton,
+  ModalContent,
+  ModalOverlay,
+  ModalTitle,
+  SubmitButton,
+  TeamDetails,
+  TeamInfo,
+} from "../Home.styled";
+
+// 기존에는 인라인 style로 쓰이던 부분 — 재사용과 테마 적용이 가능하도록 옮겼다
+const ActionRow = styled.div`
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+`;
+
+const SecondaryAction = styled(SubmitButton)`
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+`;
+
+const CloseIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+/**
+ * 랭킹처럼 로그인이 필요한 기능에 접근했을 때 안내하는 모달.
+ * 막다른 안내로 끝내지 않고 로그인·회원가입으로 이어지는 동선을 함께 제공한다.
+ */
+function LoginRequiredModal({ onClose, onGoLogin, onGoSignup }) {
+  return (
+    <ModalOverlay
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      onClick={onClose}
+    >
+      <ModalContent
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.8, opacity: 0 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ModalTitle>로그인 필요</ModalTitle>
+        <TeamInfo>
+          <TeamDetails>
+            <DetailRow>
+              <span>랭킹 보기는 로그인 후 이용할 수 있습니다.</span>
+            </DetailRow>
+            <DetailRow>
+              <span>로그인하여 다른 플레이어들과 점수를 비교해보세요!</span>
+            </DetailRow>
+          </TeamDetails>
+        </TeamInfo>
+        <ActionRow>
+          <SubmitButton
+            type="button"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={onGoLogin}
+          >
+            로그인하기
+          </SubmitButton>
+          <SecondaryAction
+            type="button"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={onGoSignup}
+          >
+            회원가입하기
+          </SecondaryAction>
+        </ActionRow>
+        <IconCloseButton
+          onClick={onClose}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          aria-label="모달 닫기"
+        >
+          <CloseIcon />
+        </IconCloseButton>
+      </ModalContent>
+    </ModalOverlay>
+  );
+}
+
+export default LoginRequiredModal;

--- a/src/pages/Home/PasswordField.jsx
+++ b/src/pages/Home/PasswordField.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+
+import { GlassInput, PasswordInputWrapper, PasswordToggleButton } from "../Home.styled";
+
+const EyeOpenIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const EyeClosedIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+    <line x1="1" y1="1" x2="23" y2="23" />
+  </svg>
+);
+
+/**
+ * 표시/숨김 토글이 달린 비밀번호 입력 필드.
+ *
+ * 로그인·회원가입 모달이 같은 마크업(아이콘 SVG 포함)을 각자 복사해 갖고 있어 하나로 모았다.
+ * 표시 여부는 필드 내부 상태다 — 바깥에서 관리할 이유가 없다.
+ */
+function PasswordField({
+  value,
+  onChange,
+  placeholder = "비밀번호를 입력해주세요",
+  required = true,
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <PasswordInputWrapper>
+      <GlassInput
+        type={isVisible ? "text" : "password"}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        required={required}
+      />
+      <PasswordToggleButton
+        type="button"
+        onClick={() => setIsVisible((prev) => !prev)}
+        aria-label={isVisible ? "비밀번호 숨기기" : "비밀번호 표시"}
+      >
+        {isVisible ? <EyeOpenIcon /> : <EyeClosedIcon />}
+      </PasswordToggleButton>
+    </PasswordInputWrapper>
+  );
+}
+
+export default PasswordField;


### PR DESCRIPTION
## 관련 이슈

- https://github.com/bagle-ggul/Bagel-Frontend/issues/100

## 개요

Phase 3의 **모달 분리** 단계입니다. `Home.jsx`에 뭉쳐 있던 모달을 컴포넌트로 떼어냈습니다.

| 파일 | 세션 시작 | 현재 |
|---|---|---|
| `src/pages/Home.jsx` | **2190줄** | **913줄** |

## 분리한 것

| 새 컴포넌트 | 역할 |
|---|---|
| `Home/CreditsModal.jsx` | 팀·해커톤 정보 |
| `Home/LoginRequiredModal.jsx` | 로그인 필요 안내 + 로그인·회원가입 동선 |
| `Home/LoginModal.jsx` | 로그인 폼 |
| `Home/PasswordField.jsx` | 표시/숨김 토글이 달린 비밀번호 입력 |

### `PasswordField`로 중복을 없앴습니다

로그인·회원가입 모달이 **눈 아이콘 SVG 두 벌을 포함한 마크업 전체를 각자 복사**해 갖고 있었습니다. 하나로 모으면서 **표시 여부 상태를 필드 내부로 옮겼습니다.**

그 결과 `Home.jsx`에서 `isPasswordVisible` 상태와 모달 닫을 때의 초기화 호출 2곳이 사라졌습니다. 모달이 닫히면 필드가 언마운트되어 자동으로 초기화되므로 바깥에서 관리할 이유가 없습니다.

### 인라인 스타일 2곳 흡수

`LoginRequiredModal`의 버튼 영역이 인라인 `style`로 되어 있던 것을 `ActionRow`·`SecondaryAction` styled 컴포넌트로 옮겼습니다.

## 검증

### 자동

| 명령 | 결과 |
|---|---|
| `format:check` | ✅ exit 0 |
| `lint` | ✅ exit 0 |
| `test:ci` | ✅ 103 tests |
| `build` | ✅ Compiled successfully |

### 브라우저 실동작

분리한 모달 3종을 실제로 열어 확인했습니다.

| 모달 | 결과 |
|---|---|
| 크레딧 | ✅ 팀 정보·멤버 목록 정상 |
| 로그인 필요 | ✅ 안내 문구 + 로그인하기/회원가입하기 버튼 정상 |
| 로그인 | ✅ 입력 필드·비밀번호 토글·제출 버튼 정상, 콘솔 에러 0 |

## 남은 작업 (이슈 #100)

- **회원가입 모달 분리** — MBTI 4개 + 생년월일 3개 + 폼 4개 등 상태 13개가 얽혀 있어, 하위 선택 컴포넌트(MBTI/생년월일/성별)부터 나누는 접근이 필요합니다
- 디자인 토큰 2계층 재설계
- 인라인 스타일 나머지
- 3해상도 전 화면 캡처
