### PR TITLE
회원가입 모달 컴포넌트 분리 (전면 표준화 Phase 3-6)

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -12,11 +12,8 @@ import { isMusicMuted, setMusicMuted } from "../utils/storage";
 import CreditsModal from "./Home/CreditsModal";
 import LoginModal from "./Home/LoginModal";
 import LoginRequiredModal from "./Home/LoginRequiredModal";
+import SignupModal from "./Home/SignupModal";
 import {
-  BirthDateContainer,
-  BirthDateRow,
-  BirthDateTitle,
-  BirthSelect,
   BottomCreditsButton,
   BottomRightButtonGroup,
   BottomVersionInfo,
@@ -24,39 +21,17 @@ import {
   ButtonWrapper,
   ChangelogLink,
   CharacterWrapper,
-  ErrorMessage,
-  GenderButton,
-  GenderButtonGroup,
-  GenderContainer,
-  GenderTitle,
-  GlassInput,
-  IconCloseButton,
   IconControlGroup,
   ImageGalleryButton,
-  InputWrapper,
-  LoginForm,
   LogoutButton,
   MainWrapper,
-  MbtiButton,
-  MbtiButtonGroup,
-  MbtiCompactContainer,
-  MbtiLabel,
-  MbtiResult,
-  MbtiRow,
-  MbtiTitle,
   MobileCharacterWrapper,
   MobileContainer,
   MobileMainWrapper,
-  ModalContent,
-  ModalOverlay,
-  ModalTitle,
   MusicControlButton,
-  PasswordInputWrapper,
-  PasswordToggleButton,
   PrimaryButton,
   SecondaryButton,
   SecondaryButtonModal,
-  SubmitButton,
   Subtitle,
   Title,
   Wrapper,
@@ -80,8 +55,6 @@ function Home() {
   const [signupEmail, setSignupEmail] = useState("");
   const [signupPassword, setSignupPassword] = useState("");
   const [signupPasswordConfirm, setSignupPasswordConfirm] = useState("");
-  const [isSignupPasswordVisible, setIsSignupPasswordVisible] = useState(false);
-  const [isSignupPasswordConfirmVisible, setIsSignupPasswordConfirmVisible] = useState(false);
   const [characterName, setCharacterName] = useState("");
   const [mbti, setMbti] = useState("");
   // MBTI 단계별 선택 상태
@@ -205,6 +178,18 @@ function Home() {
     setPassword("");
   };
 
+  // 하위 선택 컴포넌트는 "어떤 축/필드가 바뀌었는지"만 알려준다.
+  // 상태 setter와의 연결은 화면이 담당한다.
+  const handleMbtiChange = (axis, selected) => {
+    const setters = { e: setMbtiE, s: setMbtiS, t: setMbtiT, j: setMbtiJ };
+    setters[axis]?.(selected);
+  };
+
+  const handleBirthChange = (field, value) => {
+    const setters = { year: setBirthYear, month: setBirthMonth, day: setBirthDay };
+    setters[field]?.(value);
+  };
+
   const handleSignup = async (event) => {
     event.preventDefault();
     setSignupError(""); // 에러 메시지 초기화
@@ -245,8 +230,6 @@ function Home() {
       setSignupEmail("");
       setSignupPassword("");
       setSignupPasswordConfirm("");
-      setIsSignupPasswordVisible(false);
-      setIsSignupPasswordConfirmVisible(false);
       setCharacterName("");
       setMbti("");
       setMbtiE("");
@@ -270,8 +253,6 @@ function Home() {
     setSignupEmail("");
     setSignupPassword("");
     setSignupPasswordConfirm("");
-    setIsSignupPasswordVisible(false);
-    setIsSignupPasswordConfirmVisible(false);
     setCharacterName("");
     setMbti("");
     setMbtiE("");
@@ -290,8 +271,6 @@ function Home() {
     setSignupEmail("");
     setSignupPassword("");
     setSignupPasswordConfirm("");
-    setIsSignupPasswordVisible(false);
-    setIsSignupPasswordConfirmVisible(false);
     setCharacterName("");
     setMbti("");
     setMbtiE("");
@@ -534,338 +513,27 @@ function Home() {
       <AnimatePresence>
         {showCredits && <CreditsModal onClose={() => setShowCredits(false)} />}
         {showSignup && (
-          <ModalOverlay
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={closeSignupModal}
-          >
-            <ModalContent
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.8, opacity: 0 }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <ModalTitle>회원가입</ModalTitle>
-              <LoginForm onSubmit={handleSignup}>
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <GlassInput
-                    type="email"
-                    placeholder="이메일을 입력해주세요"
-                    value={signupEmail}
-                    onChange={(e) => setSignupEmail(e.target.value)}
-                    required
-                  />
-                </InputWrapper>
-
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <PasswordInputWrapper>
-                    <GlassInput
-                      type={isSignupPasswordVisible ? "text" : "password"}
-                      placeholder="비밀번호를 입력해주세요"
-                      value={signupPassword}
-                      onChange={(e) => setSignupPassword(e.target.value)}
-                      required
-                    />
-                    <PasswordToggleButton
-                      type="button"
-                      onClick={() => setIsSignupPasswordVisible(!isSignupPasswordVisible)}
-                    >
-                      {isSignupPasswordVisible ? (
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                          <circle cx="12" cy="12" r="3" />
-                        </svg>
-                      ) : (
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-                          <line x1="1" y1="1" x2="23" y2="23" />
-                        </svg>
-                      )}
-                    </PasswordToggleButton>
-                  </PasswordInputWrapper>
-                </InputWrapper>
-
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <PasswordInputWrapper>
-                    <GlassInput
-                      type={isSignupPasswordConfirmVisible ? "text" : "password"}
-                      placeholder="비밀번호를 다시 입력해주세요"
-                      value={signupPasswordConfirm}
-                      onChange={(e) => setSignupPasswordConfirm(e.target.value)}
-                      required
-                    />
-                    <PasswordToggleButton
-                      type="button"
-                      onClick={() =>
-                        setIsSignupPasswordConfirmVisible(!isSignupPasswordConfirmVisible)
-                      }
-                    >
-                      {isSignupPasswordConfirmVisible ? (
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                          <circle cx="12" cy="12" r="3" />
-                        </svg>
-                      ) : (
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-                          <line x1="1" y1="1" x2="23" y2="23" />
-                        </svg>
-                      )}
-                    </PasswordToggleButton>
-                  </PasswordInputWrapper>
-                  {signupPasswordConfirm && signupPassword !== signupPasswordConfirm && (
-                    <ErrorMessage
-                      initial={{ opacity: 0, y: -10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ duration: 0.3 }}
-                    >
-                      비밀번호가 일치하지 않습니다
-                    </ErrorMessage>
-                  )}
-                </InputWrapper>
-
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <GlassInput
-                    type="text"
-                    placeholder="이름을 입력해주세요"
-                    value={characterName}
-                    onChange={(e) => setCharacterName(e.target.value)}
-                    required
-                  />
-                </InputWrapper>
-
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <MbtiCompactContainer>
-                    <MbtiTitle>성격 유형 (MBTI)</MbtiTitle>
-
-                    <MbtiRow>
-                      <MbtiLabel>에너지</MbtiLabel>
-                      <MbtiButtonGroup>
-                        <MbtiButton
-                          selected={mbtiE === "E"}
-                          onClick={() => setMbtiE("E")}
-                          type="button"
-                        >
-                          E 외향
-                        </MbtiButton>
-                        <MbtiButton
-                          selected={mbtiE === "I"}
-                          onClick={() => setMbtiE("I")}
-                          type="button"
-                        >
-                          I 내향
-                        </MbtiButton>
-                      </MbtiButtonGroup>
-                    </MbtiRow>
-
-                    <MbtiRow>
-                      <MbtiLabel>인식</MbtiLabel>
-                      <MbtiButtonGroup>
-                        <MbtiButton
-                          selected={mbtiS === "S"}
-                          onClick={() => setMbtiS("S")}
-                          type="button"
-                        >
-                          S 감각
-                        </MbtiButton>
-                        <MbtiButton
-                          selected={mbtiS === "N"}
-                          onClick={() => setMbtiS("N")}
-                          type="button"
-                        >
-                          N 직관
-                        </MbtiButton>
-                      </MbtiButtonGroup>
-                    </MbtiRow>
-
-                    <MbtiRow>
-                      <MbtiLabel>판단</MbtiLabel>
-                      <MbtiButtonGroup>
-                        <MbtiButton
-                          selected={mbtiT === "T"}
-                          onClick={() => setMbtiT("T")}
-                          type="button"
-                        >
-                          T 사고
-                        </MbtiButton>
-                        <MbtiButton
-                          selected={mbtiT === "F"}
-                          onClick={() => setMbtiT("F")}
-                          type="button"
-                        >
-                          F 감정
-                        </MbtiButton>
-                      </MbtiButtonGroup>
-                    </MbtiRow>
-
-                    <MbtiRow>
-                      <MbtiLabel>생활</MbtiLabel>
-                      <MbtiButtonGroup>
-                        <MbtiButton
-                          selected={mbtiJ === "J"}
-                          onClick={() => setMbtiJ("J")}
-                          type="button"
-                        >
-                          J 계획
-                        </MbtiButton>
-                        <MbtiButton
-                          selected={mbtiJ === "P"}
-                          onClick={() => setMbtiJ("P")}
-                          type="button"
-                        >
-                          P 자율
-                        </MbtiButton>
-                      </MbtiButtonGroup>
-                    </MbtiRow>
-
-                    {mbti && (
-                      <MbtiResult>
-                        <span>{mbti}</span>
-                      </MbtiResult>
-                    )}
-                  </MbtiCompactContainer>
-                </InputWrapper>
-
-                <InputWrapper whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <BirthDateContainer>
-                    <BirthDateTitle>생년월일</BirthDateTitle>
-                    <BirthDateRow>
-                      <BirthSelect
-                        value={birthYear}
-                        onChange={(e) => setBirthYear(e.target.value)}
-                        required
-                      >
-                        <option value="" disabled>
-                          년도
-                        </option>
-                        {Array.from({ length: 50 }, (_, i) => new Date().getFullYear() - i).map(
-                          (year) => (
-                            <option key={year} value={year}>
-                              {year}년
-                            </option>
-                          )
-                        )}
-                      </BirthSelect>
-
-                      <BirthSelect
-                        value={birthMonth}
-                        onChange={(e) => setBirthMonth(e.target.value)}
-                        required
-                      >
-                        <option value="" disabled>
-                          월
-                        </option>
-                        {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
-                          <option key={month} value={month}>
-                            {month}월
-                          </option>
-                        ))}
-                      </BirthSelect>
-
-                      <BirthSelect
-                        value={birthDay}
-                        onChange={(e) => setBirthDay(e.target.value)}
-                        required
-                      >
-                        <option value="" disabled>
-                          일
-                        </option>
-                        {Array.from({ length: 31 }, (_, i) => i + 1).map((day) => (
-                          <option key={day} value={day}>
-                            {day}일
-                          </option>
-                        ))}
-                      </BirthSelect>
-                    </BirthDateRow>
-                  </BirthDateContainer>
-                </InputWrapper>
-
-                <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  <GenderContainer>
-                    <GenderTitle>성별</GenderTitle>
-                    <GenderButtonGroup>
-                      <GenderButton
-                        selected={gender === "남성"}
-                        onClick={() => setGender("남성")}
-                        type="button"
-                      >
-                        남성
-                      </GenderButton>
-                      <GenderButton
-                        selected={gender === "여성"}
-                        onClick={() => setGender("여성")}
-                        type="button"
-                      >
-                        여성
-                      </GenderButton>
-                    </GenderButtonGroup>
-                  </GenderContainer>
-                </motion.div>
-
-                <SubmitButton type="submit" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                  회원가입
-                </SubmitButton>
-                {signupError && (
-                  <ErrorMessage
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.3 }}
-                  >
-                    {signupError}
-                  </ErrorMessage>
-                )}
-              </LoginForm>
-              <IconCloseButton
-                onClick={closeSignupModal}
-                whileHover={{ scale: 1.1 }}
-                whileTap={{ scale: 0.95 }}
-                aria-label="회원가입 모달 닫기"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </IconCloseButton>
-            </ModalContent>
-          </ModalOverlay>
+          <SignupModal
+            email={signupEmail}
+            password={signupPassword}
+            passwordConfirm={signupPasswordConfirm}
+            characterName={characterName}
+            mbti={{ e: mbtiE, s: mbtiS, t: mbtiT, j: mbtiJ }}
+            mbtiResult={mbti}
+            birth={{ year: birthYear, month: birthMonth, day: birthDay }}
+            gender={gender}
+            error={signupError}
+            onEmailChange={(e) => setSignupEmail(e.target.value)}
+            onPasswordChange={(e) => setSignupPassword(e.target.value)}
+            onPasswordConfirmChange={(e) => setSignupPasswordConfirm(e.target.value)}
+            onCharacterNameChange={(e) => setCharacterName(e.target.value)}
+            onMbtiChange={handleMbtiChange}
+            onBirthChange={handleBirthChange}
+            onGenderChange={setGender}
+            onSubmit={handleSignup}
+            onClose={closeSignupModal}
+          />
+        )}
         )}
         {showLogin && (
           <LoginModal

--- a/src/pages/Home/BirthDateSelect.jsx
+++ b/src/pages/Home/BirthDateSelect.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+import { BirthDateContainer, BirthDateRow, BirthDateTitle, BirthSelect } from "../Home.styled";
+
+/** 선택 가능한 연도 범위 (올해부터 과거 50년) */
+const YEAR_RANGE = 50;
+
+const range = (length, start = 1) => Array.from({ length }, (_, i) => i + start);
+
+/**
+ * 생년월일 선택.
+ *
+ * 일(day)은 월과 무관하게 31일까지 제공한다. 존재하지 않는 날짜(2월 30일 등)를
+ * 고를 수 있으므로, 정확성이 필요해지면 월별 일수 계산을 추가해야 한다.
+ *
+ * @param {Object} value `{ year, month, day }`
+ * @param {Function} onChange `(field, value) => void`
+ */
+function BirthDateSelect({ value, onChange }) {
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: YEAR_RANGE }, (_, i) => currentYear - i);
+
+  return (
+    <BirthDateContainer>
+      <BirthDateTitle>생년월일</BirthDateTitle>
+      <BirthDateRow>
+        <BirthSelect value={value.year} onChange={(e) => onChange("year", e.target.value)} required>
+          <option value="" disabled>
+            년도
+          </option>
+          {years.map((year) => (
+            <option key={year} value={year}>
+              {year}년
+            </option>
+          ))}
+        </BirthSelect>
+
+        <BirthSelect
+          value={value.month}
+          onChange={(e) => onChange("month", e.target.value)}
+          required
+        >
+          <option value="" disabled>
+            월
+          </option>
+          {range(12).map((month) => (
+            <option key={month} value={month}>
+              {month}월
+            </option>
+          ))}
+        </BirthSelect>
+
+        <BirthSelect value={value.day} onChange={(e) => onChange("day", e.target.value)} required>
+          <option value="" disabled>
+            일
+          </option>
+          {range(31).map((day) => (
+            <option key={day} value={day}>
+              {day}일
+            </option>
+          ))}
+        </BirthSelect>
+      </BirthDateRow>
+    </BirthDateContainer>
+  );
+}
+
+export default BirthDateSelect;

--- a/src/pages/Home/GenderSelect.jsx
+++ b/src/pages/Home/GenderSelect.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { GenderButton, GenderButtonGroup, GenderContainer, GenderTitle } from "../Home.styled";
+
+const GENDERS = ["남성", "여성"];
+
+/**
+ * 성별 선택.
+ *
+ * @param {string} value 선택된 값
+ * @param {Function} onChange `(gender) => void`
+ */
+function GenderSelect({ value, onChange }) {
+  return (
+    <GenderContainer>
+      <GenderTitle>성별</GenderTitle>
+      <GenderButtonGroup>
+        {GENDERS.map((gender) => (
+          <GenderButton
+            key={gender}
+            type="button"
+            selected={value === gender}
+            onClick={() => onChange(gender)}
+          >
+            {gender}
+          </GenderButton>
+        ))}
+      </GenderButtonGroup>
+    </GenderContainer>
+  );
+}
+
+export default GenderSelect;

--- a/src/pages/Home/MbtiSelect.jsx
+++ b/src/pages/Home/MbtiSelect.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+
+import {
+  MbtiButton,
+  MbtiButtonGroup,
+  MbtiCompactContainer,
+  MbtiLabel,
+  MbtiResult,
+  MbtiRow,
+  MbtiTitle,
+} from "../Home.styled";
+
+/**
+ * MBTI 4개 축. 원래는 같은 마크업이 4번 복사돼 있어 92줄이었다.
+ * 축이 늘거나 라벨이 바뀌면 이 배열만 고치면 된다.
+ */
+const MBTI_AXES = [
+  {
+    key: "e",
+    label: "에너지",
+    options: [
+      ["E", "E 외향"],
+      ["I", "I 내향"],
+    ],
+  },
+  {
+    key: "s",
+    label: "인식",
+    options: [
+      ["S", "S 감각"],
+      ["N", "N 직관"],
+    ],
+  },
+  {
+    key: "t",
+    label: "판단",
+    options: [
+      ["T", "T 사고"],
+      ["F", "F 감정"],
+    ],
+  },
+  {
+    key: "j",
+    label: "생활",
+    options: [
+      ["J", "J 계획"],
+      ["P", "P 자율"],
+    ],
+  },
+];
+
+/**
+ * MBTI 선택 UI.
+ *
+ * @param {Object} value 축별 선택값 `{ e, s, t, j }`
+ * @param {Function} onChange `(axisKey, selected) => void`
+ * @param {string} [result] 완성된 MBTI 문자열. 있으면 하단에 표시
+ */
+function MbtiSelect({ value, onChange, result }) {
+  return (
+    <MbtiCompactContainer>
+      <MbtiTitle>성격 유형 (MBTI)</MbtiTitle>
+
+      {MBTI_AXES.map((axis) => (
+        <MbtiRow key={axis.key}>
+          <MbtiLabel>{axis.label}</MbtiLabel>
+          <MbtiButtonGroup>
+            {axis.options.map(([code, text]) => (
+              <MbtiButton
+                key={code}
+                type="button"
+                selected={value[axis.key] === code}
+                onClick={() => onChange(axis.key, code)}
+              >
+                {text}
+              </MbtiButton>
+            ))}
+          </MbtiButtonGroup>
+        </MbtiRow>
+      ))}
+
+      {result && (
+        <MbtiResult>
+          <span>{result}</span>
+        </MbtiResult>
+      )}
+    </MbtiCompactContainer>
+  );
+}
+
+export default MbtiSelect;

--- a/src/pages/Home/SignupModal.jsx
+++ b/src/pages/Home/SignupModal.jsx
@@ -1,0 +1,151 @@
+import { motion } from "framer-motion";
+import React from "react";
+
+import {
+  ErrorMessage,
+  GlassInput,
+  IconCloseButton,
+  InputWrapper,
+  LoginForm,
+  ModalContent,
+  ModalOverlay,
+  ModalTitle,
+  SubmitButton,
+} from "../Home.styled";
+
+import BirthDateSelect from "./BirthDateSelect";
+import GenderSelect from "./GenderSelect";
+import MbtiSelect from "./MbtiSelect";
+import PasswordField from "./PasswordField";
+
+const CloseIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+const hoverProps = { whileHover: { scale: 1.02 }, whileTap: { scale: 0.98 } };
+
+/**
+ * 회원가입 모달.
+ *
+ * 폼 상태는 화면(Home)이 소유하고 이 컴포넌트는 표현만 담당한다.
+ * MBTI·생년월일·성별은 각각 하위 컴포넌트로 분리해, 이 파일은 폼의 뼈대만 갖는다.
+ */
+function SignupModal({
+  email,
+  password,
+  passwordConfirm,
+  characterName,
+  mbti,
+  mbtiResult,
+  birth,
+  gender,
+  error,
+  onEmailChange,
+  onPasswordChange,
+  onPasswordConfirmChange,
+  onCharacterNameChange,
+  onMbtiChange,
+  onBirthChange,
+  onGenderChange,
+  onSubmit,
+  onClose,
+}) {
+  const isPasswordMismatch = passwordConfirm && password !== passwordConfirm;
+
+  return (
+    <ModalOverlay
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      onClick={onClose}
+    >
+      <ModalContent
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.8, opacity: 0 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ModalTitle>회원가입</ModalTitle>
+        <LoginForm onSubmit={onSubmit}>
+          <InputWrapper {...hoverProps}>
+            <GlassInput
+              type="email"
+              placeholder="이메일을 입력해주세요"
+              value={email}
+              onChange={onEmailChange}
+              required
+            />
+          </InputWrapper>
+
+          <InputWrapper {...hoverProps}>
+            <PasswordField value={password} onChange={onPasswordChange} />
+          </InputWrapper>
+
+          <InputWrapper {...hoverProps}>
+            <PasswordField
+              value={passwordConfirm}
+              onChange={onPasswordConfirmChange}
+              placeholder="비밀번호를 다시 입력해주세요"
+            />
+            {isPasswordMismatch && (
+              <ErrorMessage
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                비밀번호가 일치하지 않습니다
+              </ErrorMessage>
+            )}
+          </InputWrapper>
+
+          <InputWrapper {...hoverProps}>
+            <GlassInput
+              type="text"
+              placeholder="이름을 입력해주세요"
+              value={characterName}
+              onChange={onCharacterNameChange}
+              required
+            />
+          </InputWrapper>
+
+          <InputWrapper {...hoverProps}>
+            <MbtiSelect value={mbti} onChange={onMbtiChange} result={mbtiResult} />
+          </InputWrapper>
+
+          <InputWrapper {...hoverProps}>
+            <BirthDateSelect value={birth} onChange={onBirthChange} />
+          </InputWrapper>
+
+          <motion.div {...hoverProps}>
+            <GenderSelect value={gender} onChange={onGenderChange} />
+          </motion.div>
+
+          <SubmitButton type="submit" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            회원가입
+          </SubmitButton>
+          {error && (
+            <ErrorMessage
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              {error}
+            </ErrorMessage>
+          )}
+        </LoginForm>
+        <IconCloseButton
+          onClick={onClose}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          aria-label="회원가입 모달 닫기"
+        >
+          <CloseIcon />
+        </IconCloseButton>
+      </ModalContent>
+    </ModalOverlay>
+  );
+}
+
+export default SignupModal;


### PR DESCRIPTION
## 관련 이슈

- https://github.com/bagle-ggul/Bagel-Frontend/issues/100

## 개요

`Home.jsx`에 남아 있던 **가장 큰 덩어리인 회원가입 모달**을 분리했습니다.

| 파일 | 세션 시작 | 현재 |
|---|---|---|
| `src/pages/Home.jsx` | **2190줄** | **581줄** |

## 분리 방식

모달 전체를 한 번에 빼지 않고, **하위 선택 컴포넌트부터** 나눴습니다. 상태 13개가 얽혀 있어 한 번에 옮기면 props가 감당 못 할 수준이 되기 때문입니다.

| 새 컴포넌트 | 역할 |
|---|---|
| `Home/MbtiSelect.jsx` | MBTI 4축 선택 |
| `Home/BirthDateSelect.jsx` | 연/월/일 선택 |
| `Home/GenderSelect.jsx` | 성별 선택 |
| `Home/SignupModal.jsx` | 폼 뼈대 + 위 3개 조합 |

### MBTI는 데이터 기반으로 바꿨습니다

같은 마크업이 **4번 복사**돼 92줄이었습니다. 축 정의를 배열로 만들어 반복 렌더하도록 바꿨습니다. 축이 늘거나 라벨이 바뀌면 이제 배열만 고치면 됩니다.

### 비밀번호 필드 중복 제거

회원가입 모달도 `PasswordField`를 쓰도록 바꿨습니다. **눈 아이콘 SVG 두 벌을 포함한 마크업이 두 필드에 각각 복사**돼 있던 것이 사라졌습니다.

두 필드가 원래도 각자 독립된 표시 상태(`isSignupPasswordVisible`, `isSignupPasswordConfirmVisible`)를 썼기 때문에 **동작은 그대로**입니다. `Home.jsx`에서 이 상태 2개와 초기화 호출이 제거됐습니다.

### 상태 연결은 화면이 담당합니다

하위 컴포넌트는 "어떤 축/필드가 바뀌었는지"만 알려주고, setter와의 연결은 `Home`이 합니다.

```js
const handleMbtiChange = (axis, selected) => {
  const setters = { e: setMbtiE, s: setMbtiS, t: setMbtiT, j: setMbtiJ };
  setters[axis]?.(selected);
};
```

## 검증

### 자동

| 명령 | 결과 |
|---|---|
| `format:check` | ✅ exit 0 |
| `lint` | ✅ exit 0 |
| `test:ci` | ✅ 105 tests |
| `build` | ✅ Compiled successfully |

### 브라우저 실동작

회원가입 폼은 실제 가입 경로라 동작까지 확인했습니다.

| 검증 | 결과 |
|---|---|
| 모달 렌더 | ✅ 이메일·비밀번호 2개·이름·MBTI·생년월일·성별 전부 표시 |
| **MBTI 선택** | ✅ E·N·T·P 클릭 → **"ENTP" 결과 표시** |
| 성별 선택 | ✅ 정상 |
| 콘솔 에러 | ✅ 0건 |

## 이슈 #100의 남은 작업

- 디자인 토큰 2계층 재설계
- 인라인 스타일 잔여분
- 3해상도 전 화면 캡처
