### PR TITLE
3해상도 전수 점검 및 인라인 스타일 정리 (전면 표준화 Phase 3 마무리)

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -147,6 +147,39 @@ border-radius: 20px
 `animations` 객체에 Framer Motion용 variant가 정의되어 있다 — `fadeIn`, `slideUp`,
 `scaleIn`, `hover`, `tap`.
 
+## 3해상도 점검 결과
+
+| 해상도            | 결과                  |
+| ----------------- | --------------------- |
+| 모바일 390×844    | ✅ 뷰포트 초과 요소 0 |
+| 태블릿 768×1024   | ✅ 뷰포트 초과 요소 0 |
+| 데스크톱 1440×900 | ✅ 뷰포트 초과 요소 0 |
+
+### 점검 방법
+
+캡처만으로는 "조금 잘렸는지"를 눈으로 판별하기 어렵다. 그래서 **측정**했다.
+
+```js
+[...document.querySelectorAll("*")].filter(
+  (e) => e.getBoundingClientRect().right > window.innerWidth + 1
+).length;
+```
+
+가로 스크롤 발생 여부(`scrollWidth > innerWidth`)와 함께 확인한다. `overflow: hidden`이
+걸려 있으면 스크롤은 안 생기지만 요소는 여전히 화면 밖에 있으므로 둘 다 봐야 한다.
+
+### 찾아서 고친 결함
+
+**인트로 화면이 모바일에서 뷰포트를 벗어났다.**
+
+`DialogueSystem`의 `CharacterImage`가 모바일에서 `width: 500px` 고정이었고,
+부모 `CharacterContainer`에 폭 제한이 없어 자식만큼 늘어났다. 390px 화면에서
+컨테이너가 500px가 되어 레이아웃이 밀렸다.
+
+부모에 `width: 100%`, 자식에 `max-width: 100%`를 넣어 해소했다.
+`background-size: contain`이라 이미지 자체는 잘리지 않았기 때문에 **눈으로는 알아채기
+어려운 결함**이었다.
+
 ## Phase 3 계획
 
 ### 1. 전수 점검 (선행)

--- a/src/components/DialogueSystem.jsx
+++ b/src/components/DialogueSystem.jsx
@@ -40,6 +40,9 @@ const CharacterContainer = styled.div`
   align-items: center;
   gap: 0;
   margin-bottom: 1rem;
+  /* 폭 제한이 없으면 자식(CharacterImage)의 고정 폭만큼 늘어나
+     좁은 화면에서 컨테이너가 뷰포트를 벗어난다 */
+  width: 100%;
 
   ${media.mobile} {
     gap: 0;
@@ -49,6 +52,9 @@ const CharacterContainer = styled.div`
 
 const CharacterImage = styled.div`
   width: 600px; /* 1200px의 절반 */
+  /* 고정 폭이 뷰포트를 넘으면 요소가 화면 밖으로 밀린다.
+     background-size: contain이라 이미지 자체는 잘리지 않지만 레이아웃이 어긋난다. */
+  max-width: 100%;
   height: 400px; /* 800px의 절반 */
   background-image: url(${(props) => props.src});
   background-size: contain;

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -10,6 +10,25 @@ import StatsContent from "../components/StatsContent";
 import axios from "../utils/axios";
 import { logger } from "../utils/logger";
 
+// 스켈레톤 로딩 UI — 원래 인라인 style로 4번 반복되던 것
+const SkeletonList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+const SkeletonRow = styled(motion.div)`
+  width: 100%;
+  height: 48px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.2rem;
+`;
+
 const ErrorPanel = styled.div`
   display: flex;
   flex-direction: column;
@@ -175,6 +194,9 @@ const SkeletonCircle = styled(SkeletonElement)`
 const SkeletonText = styled(SkeletonElement)`
   height: 20px;
   border-radius: 4px;
+  /* 자리표시자 너비는 행마다 달라서 prop으로 받는다.
+     transient prop($ 접두사)이라 DOM으로 전달되지 않는다 */
+  width: ${(props) => props.$width || "100%"};
 `;
 
 const SkeletonTitle = styled(SkeletonElement)`
@@ -314,26 +336,14 @@ function Profile() {
         >
           <SkeletonCircle />
           <SkeletonTitle />
-          <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "0.8rem" }}>
+          <SkeletonList>
             {[...Array(4)].map((_, i) => (
-              <motion.div
-                key={i}
-                style={{
-                  width: "100%",
-                  height: "48px",
-                  background: "rgba(255, 255, 255, 0.1)",
-                  borderRadius: "12px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "0 1.2rem",
-                }}
-              >
-                <SkeletonText style={{ width: "30%" }} />
-                <SkeletonText style={{ width: "40%" }} />
-              </motion.div>
+              <SkeletonRow key={i}>
+                <SkeletonText $width="30%" />
+                <SkeletonText $width="40%" />
+              </SkeletonRow>
             ))}
-          </div>
+          </SkeletonList>
         </SkeletonCard>
 
         <SkeletonCard
@@ -342,26 +352,14 @@ function Profile() {
           transition={{ duration: 0.8, delay: 0.2 }}
         >
           <SkeletonTitle />
-          <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "0.8rem" }}>
+          <SkeletonList>
             {[...Array(2)].map((_, i) => (
-              <motion.div
-                key={i}
-                style={{
-                  width: "100%",
-                  height: "48px",
-                  background: "rgba(255, 255, 255, 0.1)",
-                  borderRadius: "12px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "0 1.2rem",
-                }}
-              >
-                <SkeletonText style={{ width: "50%" }} />
-                <SkeletonText style={{ width: "30%" }} />
-              </motion.div>
+              <SkeletonRow key={i}>
+                <SkeletonText $width="50%" />
+                <SkeletonText $width="30%" />
+              </SkeletonRow>
             ))}
-          </div>
+          </SkeletonList>
         </SkeletonCard>
       </DesktopContainer>
 
@@ -373,26 +371,14 @@ function Profile() {
         >
           <SkeletonCircle />
           <SkeletonTitle />
-          <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "0.8rem" }}>
+          <SkeletonList>
             {[...Array(4)].map((_, i) => (
-              <motion.div
-                key={i}
-                style={{
-                  width: "100%",
-                  height: "48px",
-                  background: "rgba(255, 255, 255, 0.1)",
-                  borderRadius: "12px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "0 1.2rem",
-                }}
-              >
-                <SkeletonText style={{ width: "30%" }} />
-                <SkeletonText style={{ width: "40%" }} />
-              </motion.div>
+              <SkeletonRow key={i}>
+                <SkeletonText $width="30%" />
+                <SkeletonText $width="40%" />
+              </SkeletonRow>
             ))}
-          </div>
+          </SkeletonList>
         </SkeletonCard>
 
         <SkeletonCard
@@ -401,26 +387,14 @@ function Profile() {
           transition={{ duration: 0.8, delay: 0.2 }}
         >
           <SkeletonTitle />
-          <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "0.8rem" }}>
+          <SkeletonList>
             {[...Array(2)].map((_, i) => (
-              <motion.div
-                key={i}
-                style={{
-                  width: "100%",
-                  height: "48px",
-                  background: "rgba(255, 255, 255, 0.1)",
-                  borderRadius: "12px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "0 1.2rem",
-                }}
-              >
-                <SkeletonText style={{ width: "50%" }} />
-                <SkeletonText style={{ width: "30%" }} />
-              </motion.div>
+              <SkeletonRow key={i}>
+                <SkeletonText $width="50%" />
+                <SkeletonText $width="30%" />
+              </SkeletonRow>
             ))}
-          </div>
+          </SkeletonList>
         </SkeletonCard>
       </MobileContainer>
     </>


### PR DESCRIPTION
## 관련 이슈

- https://github.com/bagle-ggul/Bagel-Frontend/issues/100

## 개요

Phase 3의 **마지막 항목** — 3해상도 전수 점검과 인라인 스타일 정리입니다.

## 1. 3해상도 전수 점검 — 실제 결함 발견

### 캡처만 보지 않고 측정했습니다

"조금 잘렸는지"는 눈으로 판별하기 어렵습니다. 그래서 뷰포트를 벗어난 요소를 **직접 셌습니다.**

```js
[...document.querySelectorAll("*")]
  .filter((e) => e.getBoundingClientRect().right > window.innerWidth + 1).length
```

가로 스크롤 발생 여부와 함께 봅니다. `overflow: hidden`이 걸려 있으면 **스크롤은 안 생기지만 요소는 여전히 화면 밖**에 있기 때문입니다.

### 찾은 결함: 모바일 인트로가 뷰포트를 벗어남

`DialogueSystem`의 `CharacterImage`가 모바일에서 `width: 500px` 고정이었고, 부모 `CharacterContainer`에 폭 제한이 없어 **자식만큼 늘어났습니다.** 390px 화면에서 컨테이너가 500px가 되어 레이아웃이 밀렸습니다.

`background-size: contain`이라 이미지 자체는 잘리지 않아 **눈으로는 알아채기 어려운 결함**이었습니다.

**수정**: 부모에 `width: 100%`, 자식에 `max-width: 100%`

### 최종 결과

| 해상도 | 결과 |
|---|---|
| 모바일 390×844 | ✅ 뷰포트 초과 요소 **0** |
| 태블릿 768×1024 | ✅ **0** |
| 데스크톱 1440×900 | ✅ **0** |

## 2. 인라인 스타일 정리

`Profile.jsx`의 스켈레톤 로딩 UI가 **같은 인라인 스타일을 4번 반복**하고 있었습니다.

`SkeletonList`·`SkeletonRow` styled 컴포넌트로 추출하고, 행마다 다른 너비는 **transient prop**(`$width`)으로 받게 했습니다.

| 항목 | 이전 | 현재 |
|---|---|---|
| 전체 인라인 스타일 | 34곳 | **18곳** |
| `Profile.jsx` | 16곳 | **0곳** |

남은 18곳은 애니메이션 진행률 등 **동적 계산값** 위주이며, `docs/CONVENTIONS.md`가 허용하는 예외입니다.

## 검증

| 명령 | 결과 |
|---|---|
| `format:check` | ✅ exit 0 |
| `lint` | ✅ exit 0 |
| `test:ci` | ✅ 130 tests |
| `build` | ✅ Compiled successfully |
| 3해상도 초과 요소 | ✅ 전부 0 |

수정 후 모바일 인트로를 재캡처해 캐릭터 이미지·대사창·Skip 버튼·진행 컨트롤이 모두 화면 안에 정확히 들어오는 것을 확인했습니다.
